### PR TITLE
Allow for duplicate labels.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ end
 
 gem 'rubocop', '~> 0.35.0', require: false
 gem 'blacklight', '~> 5.16'
-gem 'blacklight-spotlight', github: 'sul-dlss/spotlight'
+gem 'blacklight-spotlight', github: 'pulibrary/spotlight', branch: 'readonly_field_names'
 gem 'jettywrapper', '>= 2.0'
 gem 'rsolr', '~> 1.0.6'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,17 +11,9 @@ GIT
       susy (~> 2.2.12)
 
 GIT
-  remote: git://github.com/sul-dlss/spotlight-resources-iiif.git
-  revision: e98c2f565bd09466b0697a1121ed21595cfe4f03
-  specs:
-    spotlight-resources-iiif (0.1.1)
-      blacklight-spotlight
-      faraday
-      iiif-presentation
-
-GIT
-  remote: git://github.com/sul-dlss/spotlight.git
-  revision: 84632ff9ba3b7d16f6c727aca53f9912a3b15978
+  remote: git://github.com/pulibrary/spotlight.git
+  revision: 06934a5fdabadc2b46663876f3a948ee32f973e8
+  branch: readonly_field_names
   specs:
     blacklight-spotlight (0.17.1)
       acts-as-taggable-on (~> 3.5)
@@ -55,6 +47,15 @@ GIT
       social-share-button (~> 0.1.5)
       tophat
       underscore-rails (~> 1.6)
+
+GIT
+  remote: git://github.com/sul-dlss/spotlight-resources-iiif.git
+  revision: e98c2f565bd09466b0697a1121ed21595cfe4f03
+  specs:
+    spotlight-resources-iiif (0.1.1)
+      blacklight-spotlight
+      faraday
+      iiif-presentation
 
 GEM
   remote: https://rubygems.org/
@@ -385,7 +386,7 @@ GEM
       redis (~> 3.0, >= 3.0.4)
     representable (2.3.0)
       uber (~> 0.0.7)
-    request_store (1.3.0)
+    request_store (1.3.1)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
     retriable (1.4.1)

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -11,7 +11,7 @@ describe IIIFResource do
       solr_doc = nil
       resource.to_solr { |x| solr_doc = x }
       expect(solr_doc["full_title_ssim"]).to eq 'Christopher and his kind, 1929-1939'
-      expect(solr_doc["date-created_tesim"]).to eq ['1976', '2010']
+      expect(solr_doc["readonly_date-created_tesim"]).to eq ['1976', '2010']
     end
     context "when given a MVW", vcr: { cassette_name: 'mvw' } do
       let(:url) { "https://hydra-dev.princeton.edu/concern/multi_volume_works/f4752g76q/manifest" }


### PR DESCRIPTION
This allows for a readonly AND a non-readonly field with a given label to exist, with different metadata.

Closes #63