### PR TITLE
Display an icon for imported fields in metadata.

### DIFF
--- a/app/assets/javascripts/pom_boot.es6
+++ b/app/assets/javascripts/pom_boot.es6
@@ -3,9 +3,14 @@ export default class Initializer {
   constructor() {
     this.initialize_blacklight_oembed()
     this.universal_viewer = new UniversalViewer
+    this.initialize_tooltips()
   }
 
   initialize_blacklight_oembed() {
     $("[data-embed-url]").oEmbed()
+  }
+
+  initialize_tooltips() {
+    $('[data-toggle="tooltip"]').tooltip()
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,3 +53,7 @@ li[dir=rtl] {
     margin-top: -1px;
   }
 }
+
+.import-tooltip {
+  margin-left: 10px;
+}

--- a/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
+++ b/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
@@ -1,0 +1,19 @@
+<tr data-id="<%= key.parameterize %>" class="dd-item">
+  <%= f.fields_for key do |field| %>
+    <td>
+      <%= field.hidden_field :weight, 'data-property' => 'weight' %>
+      <div class="handle-wrap" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
+        <div class="dd-handle dd3-handle"><%= t :drag %></div>
+        <a href="#edit-in-place" class="field-label edit-in-place"><%= index_field_label(nil, key) %></a>
+        <%- if @exhibit.custom_fields.vocab.map(&:field).include?(key) %>
+          <span class="import-tooltip glyphicon glyphicon-import" title="Imported from Plum" data-toggle="tooltip"></span>
+        <% end %>
+        <%= field.hidden_field :label, value: index_field_label(nil, key), class: 'form-control input-sm', data: {:"edit-field-target" => 'true'} %>
+       </div>
+    </td>
+    <td class="checkbox-cell text-center"><%= field.check_box :show, inline: true, checked: config.show, label: "" %></td>
+    <% available_view_fields.keys.each do |type| %>
+    <td class="checkbox-cell text-center"><%= field.check_box type, inline: true, checked: config.send(type), label: "" %></td>
+    <% end %>
+  <% end %>
+</tr>

--- a/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'spotlight/metadata_configurations/_metadata_field', type: :view do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:p) { 'spotlight/metadata_configurations/metadata_field.html.erb' }
+  before do
+    assign(:exhibit, exhibit)
+    assign(:blacklight_configuration, exhibit.blacklight_configuration)
+    allow(view).to receive_messages(
+      current_exhibit: exhibit,
+      blacklight_config: exhibit.blacklight_configuration,
+      available_view_fields: { some_view_type: 1, another_view_type: 2 },
+      select_deselect_button: nil
+    )
+  end
+
+  let(:facet_field) { Blacklight::Configuration::FacetField.new }
+  let(:builder) { ActionView::Helpers::FormBuilder.new 'z', nil, view, {} }
+
+  it 'renders a tooltip for imported fields' do
+    Spotlight::CustomField.create!(exhibit: exhibit, slug: "two", field: "two", label: "two", field_type: "vocab", readonly_field: true)
+    allow(view).to receive(:index_field_label).with(nil, 'two').and_return 'Some label'
+    render partial: p, locals: { key: 'two', config: facet_field, f: builder }
+
+    expect(rendered).to have_selector '.import-tooltip'
+  end
+
+  it "doesn't render a tooltip for writeable fields" do
+    Spotlight::CustomField.create!(exhibit: exhibit, slug: "two", field: "two", label: "two", field_type: "vocab", readonly_field: false)
+    allow(view).to receive(:index_field_label).with(nil, 'two').and_return 'Some label'
+    render partial: p, locals: { key: 'two', config: facet_field, f: builder }
+
+    expect(rendered).to have_selector '.import-tooltip'
+  end
+end


### PR DESCRIPTION
Looks like this:

<img width="787" alt="screen shot 2016-12-21 at 1 54 24 pm" src="https://cloud.githubusercontent.com/assets/2806645/21407395/0c0d5f5c-c785-11e6-9c53-a83d536f428f.png">
