### PR TITLE
Remove slow warning message.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,3 +97,4 @@ gem 'pul-assets', github: 'pulibrary/pul_assets'
 gem 'spotlight-resources-iiif', github: 'pulibrary/spotlight-resources-iiif', branch: 'default_vocab'
 gem 'newrelic_rpm'
 gem 'dalli'
+gem 'ruby-prof', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ GEM
     rubocop-rspec (1.7.0)
       rubocop (>= 0.42.0)
     ruby-oembed (0.10.1)
+    ruby-prof (0.16.2)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.0)
     safe_yaml (1.0.4)
@@ -598,6 +599,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.41, >= 0.41.2)
   rubocop-rspec
+  ruby-prof
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sidekiq

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -1,0 +1,43 @@
+<%= bootstrap_form_for document, url: spotlight.polymorphic_path([current_exhibit, document]), html: {:'data-form-observer' => true, multipart: true} do |f| %>
+<div class="edit-fields">
+  
+  <%= f.fields_for :sidecar, document.sidecar(current_exhibit) do |c| %>
+    <%= c.check_box :public %>
+  <% end %>
+
+  <%= f.fields_for :uploaded_resource do |r| %>
+    <%= r.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.allowed_upload_extensions.join(' ')), label: "File" %>
+  <% end if document.uploaded_resource? %>
+
+  <%= f.fields_for :sidecar, document.sidecar(current_exhibit) do |c| %>
+    <%= c.fields_for :data do |d| %>
+      <% if document.uploaded_resource? %>
+        <%= d.fields_for :configured_fields do |e| %>
+          <% Spotlight::Resources::Upload.fields(current_exhibit).each do |config| %>
+            <%= e.send((config.form_field_type || :text_field), config.field_name, value: (document.sidecar(current_exhibit).data["configured_fields"] || {})[config.field_name.to_s], label: uploaded_field_label(config)) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% current_exhibit.custom_fields.each do |field| %>
+        <div class="form-group">
+          <%= d.label field.field, field.label %>
+          <%= d.text_field_without_bootstrap field.field, value: document.sidecar(current_exhibit).data[field.field.to_s], class: 'form-control', readonly: field.readonly_field? %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if can? :tag, current_exhibit %>
+  <div class="edit-tags">
+  <%= f.text_field :exhibit_tag_list, value: f.object.tags_from(current_exhibit).to_s, 'data-autocomplete_url' => exhibit_tags_path(current_exhibit, format: 'json') %>
+  </div>
+  <% end %>
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= cancel_link document, spotlight.polymorphic_path([current_exhibit, document]), class: 'btn btn-link' %>
+      <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
+  </div>
+</div>
+<% end %>

--- a/config.ru
+++ b/config.ru
@@ -2,3 +2,4 @@
 
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application
+# use Rack::RubyProf, :path => '/tmp/profile', printers: {::RubyProf::CallStackPrinter => 'call_stack.html'}


### PR DESCRIPTION
Checking to see if the custom field was configured to view resulted a
huge number of blacklight config generations. Removing this makes 45s
load times go to 5s.