### PR TITLE
Masthead adjustments & UV scrolling fix

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,11 +92,6 @@ li[dir=rtl] {
   font-size: 1.3em;
 }
 
-.site-title-container {
-  div.h1.site-title, a, a:visited {
-    color: #e87722;
-  }
-}
 .image-masthead .navbar {
   a.navbar-brand, a:visited.navbar-brand, a:hover.navbar-brand {
     color: #2b2b2b;
@@ -110,6 +105,7 @@ li[dir=rtl] {
   width: 60%;
   display: inline-block;
 }
+
 .exhibit-card:hover .flipping {
   /*Flip */
   -webkit-transform: rotateY(0.5turn);
@@ -197,4 +193,13 @@ body { -webkit-perspective: 800px; -moz-perspective: 800px; -o-perspective: 800p
       padding-top: 0;
     }
   }
+}
+.uv__overlay {
+  background:transparent;
+  position:relative;
+  width:100%;
+  height:400px;
+  top:400px;
+  margin-top:-400px;
+  z-index: 1000;
 }

--- a/app/views/catalog/_universal_viewer_default.html.erb
+++ b/app/views/catalog/_universal_viewer_default.html.erb
@@ -1,2 +1,3 @@
+<div class="uv__overlay" onClick="style.pointerEvents='none'"></div>
 <div class="uv viewer" data-config="/uv_config.json" data-uri="<%= document.fetch(Spotlight::Resources::Iiif::Engine.config.iiif_manifest_field).first %>"></div>
 <%= PulUvRails::UniversalViewer.script_tag %>

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -31,8 +31,8 @@
 
   </head>
   <body class="<%= render_body_class %>">
-  <%= render partial: 'pul-assets/header_navbar' %>
   <%= render partial: 'shared/announcements' %>
+  <%= render partial: 'pul-assets/header_navbar' %>
   <%= render partial: 'shared/masthead' %>
   <%= content_for?(:header_content) ? yield(:header_content) : "" %>
 

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,3 +1,5 @@
 <div class="alert alert-warning beta">
+  <div class="container">
     <p><strong>This is Beta Software.</strong> There may be features missing.</p>
+  </div>
 </div>

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -6,7 +6,7 @@
     <span class='background-container' style="background-image: url('<%= current_masthead.iiif_url %>')"></span>
     <span class='background-container-gradient'></span>
   <% end %>
-  
+
   <div class="container site-title-container">
     <div class="site-title h1">
       <% if content_for? :masthead %>
@@ -17,7 +17,6 @@
           <small><%= current_exhibit.subtitle %></small>
         <% end %>
       <% else %>
-        <%= image_tag "dpul.svg", class: 'logo-image' %>
         <%= application_name %>
         <% if current_site.subtitle.present? %>
           <small><%= current_site.subtitle %></small>


### PR DESCRIPTION
Remove logo. Closes #229

Move beta banner to top & align text to match the rest of the site

Change site title color. Closes #270

Add overlay hack to UV so users don't get stuck on viewer on scroll