### PR TITLE
Increase Sneakers sync job timeout

### DIFF
--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -6,7 +6,16 @@ Sneakers.configure(
   exchange: Pomegranate.config["events"]["exchange"],
   exchange_type: :fanout,
   handler: Sneakers::Handlers::Maxretry,
-  timeout_job_after: 300
+  before_fork: lambda {
+    ActiveSupport.on_load(:active_record) do
+      ActiveRecord::Base.connection_pool.disconnect!
+    end
+  },
+  after_fork: lambda {
+    ActiveSupport.on_load(:active_record) do
+      ActiveRecord::Base.establish_connection
+    end
+  }
 )
 Sneakers.logger.level = Logger::INFO
 
@@ -14,8 +23,8 @@ WORKER_OPTIONS = {
   ack: true,
   threads: 5,
   prefetch: 10,
-  timeout_job_after: 300,
+  timeout_job_after: 60,
   heartbeat: 5,
   amqp_heartbeat: 10,
-  retry_timeout: 300 * 1000 # 5 minutes
+  retry_timeout: 60 * 1000 # 5 minutes
 }.freeze

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -5,7 +5,8 @@ Sneakers.configure(
   amqp: Pomegranate.config["events"]["server"],
   exchange: Pomegranate.config["events"]["exchange"],
   exchange_type: :fanout,
-  handler: Sneakers::Handlers::Maxretry
+  handler: Sneakers::Handlers::Maxretry,
+  timeout_job_after: 300
 )
 Sneakers.logger.level = Logger::INFO
 
@@ -13,8 +14,8 @@ WORKER_OPTIONS = {
   ack: true,
   threads: 5,
   prefetch: 10,
-  timeout_job_after: 60,
+  timeout_job_after: 300,
   heartbeat: 5,
   amqp_heartbeat: 10,
-  retry_timeout: 60 * 1000 # 60 seconds
+  retry_timeout: 300 * 1000 # 5 minutes
 }.freeze


### PR DESCRIPTION
Reindexing some items after getting a message was taking longer than the
60 second timeout, resulting in the connection getting cut.