### PR TITLE
Enable Tags

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,6 @@
+/*
+*= require bootstrap-tagsinput
+*/
 @import 'utils/variables__bootstrap'; // pul bootstrap variables override
 
 @import 'bootstrap-sprockets';
@@ -5,8 +8,6 @@
 @import 'bootstrap';
 
 @import 'blacklight/blacklight';
-
-@import 'bootstrap-tagsinput';
 
 @import 'spotlight/variables_bootstrap';
 @import 'bootstrap-sprockets';
@@ -202,4 +203,15 @@ body { -webkit-perspective: 800px; -moz-perspective: 800px; -o-perspective: 800p
   top:400px;
   margin-top:-400px;
   z-index: 1000;
+}
+.edit-tags .twitter-typeahead input {
+  border: none;
+  background-color: transparent;
+  font-size: 14px;
+  margin: 0;
+  padding: 0;
+  min-height: 25px;
+}
+.bootstrap-tagsinput .tag {
+  line-height: 2;
 }

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,8 +34,4 @@ class SolrDocument
   def to_param
     first("access_identifier_ssim") || id
   end
-
-  def tags_to_solr
-    {}
-  end
 end


### PR DESCRIPTION
Closes #255 

These were previously turned off because of indexing errors a long time ago, but a reindex on staging with them turned on shows that they seem to work fine now. This also fixes the CSS for the tag edit field.