### PR TITLE
Ensuring that the IndexPresenter label for titles is a single String value in the index masonry view by implementing `IndexHelper#index_masonry_document_label`

### DIFF
--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -1,6 +1,6 @@
 module IndexHelper
   def render_index_document(document)
-    field = index_presenter(document).label(document_show_link_field(document))
+    field = field_from document: document
     span = []
     if !field.is_a?(Array)
       span << content_tag(:span, style: 'display: block;', dir: field.dir) do
@@ -15,4 +15,19 @@ module IndexHelper
     end
     safe_join span
   end
+
+  # Ensures that only a single string is passed from the IndexPresenter
+  # @param current_presenter [Class]
+  # @param show_link_field [Symbol]
+  # @return [String]
+  def index_masonry_document_label(document)
+    field = field_from document: document
+    Array.wrap(field).first
+  end
+
+  private
+
+    def field_from(document:)
+      index_presenter(document).label(document_show_link_field(document))
+    end
 end

--- a/app/views/catalog/_index_masonry_default.html.erb
+++ b/app/views/catalog/_index_masonry_default.html.erb
@@ -1,0 +1,1 @@
+<%= link_to_document(document, truncate(index_masonry_document_label(document), length: 89)) %>

--- a/spec/helpers/index_helper_spec.rb
+++ b/spec/helpers/index_helper_spec.rb
@@ -21,6 +21,30 @@ describe IndexHelper do
     Object.send(:remove_const, :TestingHelper)
   end
 
+  describe '#index_masonry_document_label' do
+    subject(:output) { helper.index_masonry_document_label(document) }
+
+    let(:label) { 'title' }
+
+    before do
+      allow(helper).to receive(:index_presenter).and_return(index_presenter)
+      allow(helper).to receive(:document_show_link_field).and_return(:full_title_tesim)
+      allow(index_presenter).to receive(:label).and_return(label)
+    end
+
+    it 'retrieves the label using the title' do
+      expect(output).to eq 'title'
+    end
+
+    context 'when multiple titles exist' do
+      let(:label) { ['title1', 'title2'] }
+
+      it 'retrieves the label using only the first title' do
+        expect(output).to eq 'title1'
+      end
+    end
+  end
+
   describe '#render_index_document' do
     before do
       allow(helper).to receive(:index_presenter).and_return(index_presenter)


### PR DESCRIPTION
Resolves #365 