### PR TITLE
Reduce exhibit-card image size and allow more cards per row on home page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -216,3 +216,6 @@ body { -webkit-perspective: 800px; -moz-perspective: 800px; -o-perspective: 800p
 .bootstrap-tagsinput .tag {
   line-height: 2;
 }
+.tab-content {
+  padding: 1em .1em;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 
 @import 'blacklight/blacklight';
 
+@import 'application_variables';
 @import 'spotlight/variables_bootstrap';
 @import 'bootstrap-sprockets';
 @import 'bootstrap';

--- a/app/assets/stylesheets/application_variables.scss
+++ b/app/assets/stylesheets/application_variables.scss
@@ -1,0 +1,1 @@
+$exhibit-card-image-size: 260px;

--- a/app/assets/stylesheets/application_variables.scss
+++ b/app/assets/stylesheets/application_variables.scss
@@ -1,1 +1,2 @@
-$exhibit-card-image-size: 260px;
+/* default was 16px */
+$exhibit-card-gutter: 12px;

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -17,7 +17,10 @@
         <%= render 'missing_exhibits' %>
       <% else %>
         <%= render 'tags', tags: @exhibits.published.all_tags %>
-        <%= render 'exhibits', exhibits: @published_exhibits %>
+        <%# Local modification: replaced rendering _exhibits partial, which splits into groups of 3, with the collection directly %>
+        <div>
+          <%= render collection: @published_exhibits, partial: 'exhibit_card', as: 'exhibit' %>
+        </div>
 
         <% if @published_exhibits.total_count > @published_exhibits.size %>
           <nav>


### PR DESCRIPTION
fixes #377