### PR TITLE
Add whitespace:pre-wrap CSS property to description list element

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -243,3 +243,10 @@ body { -webkit-perspective: 800px; -moz-perspective: 800px; -o-perspective: 800p
 .dl-horizontal dd ul {
   word-break: normal;
 }
+dd {
+  &.blacklight-readonly_description_ssim {
+    ul li {
+      white-space: pre-wrap;
+    }
+  }
+}


### PR DESCRIPTION
Closes #429 

<img width="733" alt="screenshot 2018-10-04 20 21 12" src="https://user-images.githubusercontent.com/784196/46511316-8cfb1880-c813-11e8-89b9-f8e066f2426d.png">
