### PR TITLE
Enable facet limits

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,8 +8,8 @@ class CatalogController < ApplicationController
     return if current_exhibit
     blacklight_config.add_index_field 'readonly_creator_ssim', label: 'Creator'
 
-    blacklight_config.add_facet_field 'readonly_language_ssim', label: 'Language'
-    blacklight_config.add_facet_field 'readonly_subject_ssim', label: 'Subject'
+    blacklight_config.add_facet_field 'readonly_language_ssim', label: 'Language', limit: 10
+    blacklight_config.add_facet_field 'readonly_subject_ssim', label: 'Subject', limit: 10
     unique_custom_fields.each do |field|
       blacklight_config.add_show_field field.field, label: field.configuration["label"]
     end
@@ -58,7 +58,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'sort_author', sort: 'sort_author_ssi asc, sort_title_ssi asc', label: 'Author'
 
     config.add_facet_field 'spotlight_resource_type_ssim'
-    config.add_facet_field 'readonly_collections_ssim', label: 'Collections'
+    config.add_facet_field 'readonly_collections_ssim', label: 'Collections', limit: 10
     config.add_index_field 'readonly_collections_ssim', label: 'Collections'
     config.index.thumbnail_field = 'thumbnail_ssim'
 
@@ -71,6 +71,14 @@ class CatalogController < ApplicationController
     config.index.document_actions.delete(:bookmark)
     config.repository_class = ::FriendlyIdRepository
     config.http_method = :post
+  end
+
+  # Overrides the spotlight search_facet_url method to use
+  # facet_catalog_url named route instead of catalog_facet_url.
+  # https://github.com/projectblacklight/spotlight/blob/v1.4.1/app/controllers/concerns/spotlight/controller.rb#L63
+  def search_facet_url(*args)
+    return super if current_exhibit
+    main_app.facet_catalog_url(*args)
   end
 
   # get a single document from the index

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Catalog', type: :feature do
       sign_in user
       document.make_public! exhibit
       document.reindex
-      Blacklight.default_index.connection.commit
+      index.commit
     end
 
     scenario 'user searches for a collections with a keyword' do
@@ -71,7 +71,7 @@ RSpec.feature 'Catalog', type: :feature do
         )
         document2.make_private!(exhibit2)
         document2.save
-        Blacklight.default_index.connection.commit
+        index.commit
       end
 
       scenario 'user searches for a collections with a keyword in quotes' do
@@ -85,5 +85,41 @@ RSpec.feature 'Catalog', type: :feature do
       expect(page).to have_link 'Home', href: '/exhibit-a'
       expect(page).to have_css '#documents .document h3.index_title', text: id
     end
+  end
+
+  context 'when searching across a catalog with many languages' do
+    let(:languages) {
+      [
+        'Language 1',
+        'Language 2',
+        'Language 3',
+        'Language 4',
+        'Language 5',
+        'Language 6',
+        'Language 7',
+        'Language 8',
+        'Language 9',
+        'Language 10',
+        'Language 11'
+      ]
+    }
+
+    before do
+      index.add(id: '1',
+                full_title_ssim: ['Test Item'],
+                readonly_title_ssim: ['Test Item'],
+                spotlight_resource_type_ssim: ['iiif_resources'],
+                readonly_language_ssim: languages)
+      index.commit
+    end
+
+    it 'renders the languages facet with a more facets link' do
+      visit main_app.search_catalog_path(q: '')
+      expect(page).to have_link("more", href: '/catalog/facet/readonly_language_ssim')
+    end
+  end
+
+  def index
+    Blacklight.default_index.connection
   end
 end


### PR DESCRIPTION
For reasons that I can't determine, the named route for catalog facets in our  application (`facet_catalog_url`) is the inverse of the named route referenced in Spotlight  (`catalog_facet_url`). This PR proposes an override of the `search_facet_url` CatalogController method to account for this difference and enable facet limits.

Closes #424 