### PR TITLE
Extends Sir Trevor <textarea> blocks for usage with custom metadata fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 /coverage/*
 /public/uploads
 
+*#
+*\.\#*
+*~

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/BlockLength:
     - 'app/controllers/catalog_controller.rb'
     - 'lib/tasks/dev.rake'
     - 'spec/**/*'
+    - 'config/routes.rb'
 
 Style/BlockDelimiters:
   Exclude:
@@ -119,6 +120,14 @@ Rails/DynamicFindBy:
     - 'app/models/exhibit_proxy.rb'
     - 'app/decorators/applies_title_from_slug.rb'
     - 'app/values/manifest_metadata.rb'
+
+Rails/ExampleLength:
+  Exclude:
+    - 'spec/controllers/pomegranate/metadata_configurations_controller_spec.rb'
+    - 'spec/controllers/catalog_controller_spec.rb'
+    - 'spec/models/iiif_resource_spec.rb'
+    - 'spec/services/figgy_event_processor_spec.rb'
+    - 'spec/workers/figgy_event_handler_spec.rb'
 
 RSpec/ExampleWording:
   CustomTransform:

--- a/app/controllers/pomegranate/metadata_configurations_controller.rb
+++ b/app/controllers/pomegranate/metadata_configurations_controller.rb
@@ -1,0 +1,14 @@
+
+module Pomegranate
+  class MetadataConfigurationsController < Spotlight::MetadataConfigurationsController
+    private
+
+      def exhibit_configuration_index_params
+        views = @blacklight_configuration.default_blacklight_config.view.keys | [:show]
+
+        @blacklight_configuration.blacklight_config.index_fields.keys.each_with_object({}) do |element, result|
+          result[element] = (%i[enabled label weight text_area] | views)
+        end
+      end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,26 @@ module ApplicationHelper
   def current_year
     Date.today.year
   end
+
+  def text_area?(field, exhibit)
+    index_field_config = exhibit.blacklight_config.index_fields[field.field]
+
+    index_field_config.text_area == "1"
+  end
+
+  def text_area_value(field, sidecar)
+    output = { data: [] }
+
+    field_values = sidecar.data[field.field.to_s]
+    return output.to_json if field_values.blank?
+
+    field_values
+  end
+
+  def readonly?(field)
+    custom_field = Spotlight::CustomField.find_by(field: field)
+    return true if custom_field.nil?
+
+    custom_field.readonly_field
+  end
 end

--- a/app/processors/custom_field_rendering.rb
+++ b/app/processors/custom_field_rendering.rb
@@ -1,0 +1,23 @@
+# Joins values using configured value or linebreak
+class CustomFieldRendering < Blacklight::Rendering::AbstractStep
+  include ActionView::Helpers::TextHelper
+
+  def render
+    rendered_values = Array.wrap(values)
+
+    if config.text_area == "1"
+      begin
+        parsed = JSON.parse(values)
+        data = parsed["data"]
+        rendered_values = data.map { |d| d["data"]["text"] }
+      rescue JSON::ParserError
+        # In the case that this is not a JSON data parameter, do not parse the values
+        rendered_values = Array.wrap(values)
+      end
+    end
+    options = config.separator_options || {}
+    rendered = rendered_values.to_sentence(options)
+
+    next_step(rendered)
+  end
+end

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -20,6 +20,8 @@
           <%= d.label field.field, field.label %>
           <% if field.readonly_field? %>
             <%= d.text_field_without_bootstrap field.field, value: document.sidecar(current_exhibit).data[field.field.to_s], class: 'form-control', readonly: field.readonly_field?, name: nil%>
+	  <% elsif text_area?(field, current_exhibit) %>
+	    <%= d.text_area_without_bootstrap field.field, value: text_area_value(field, f.object.sidecar(current_exhibit)), class: 'js-st-instance', data: { 'block-types': Spotlight::Engine.config.sir_trevor_widgets } %>
           <% else %>
             <%= d.text_field_without_bootstrap field.field, value: document.sidecar(current_exhibit).data[field.field.to_s], class: 'form-control', readonly: field.readonly_field? %>
           <% end %>
@@ -35,10 +37,11 @@
   <% end %>
 
   <% if can? :tag, current_exhibit %>
-  <div class="edit-tags">
-  <%= f.text_field :exhibit_tag_list, value: f.object.sidecar(current_exhibit).tags_from(current_exhibit).to_s, 'data-autocomplete_url' => exhibit_tags_path(current_exhibit, format: 'json') %>
-  </div>
+    <div class="edit-tags">
+      <%= f.text_field :exhibit_tag_list, value: f.object.sidecar(current_exhibit).tags_from(current_exhibit).to_s, 'data-autocomplete_url' => exhibit_tags_path(current_exhibit, format: 'json') %>
+    </div>
   <% end %>
+
   <div class="form-actions">
     <div class="primary-actions">
       <%= cancel_link document, spotlight.polymorphic_path([current_exhibit, document]), class: 'btn btn-link' %>

--- a/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
+++ b/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
@@ -9,11 +9,12 @@
           <span class="import-tooltip glyphicon glyphicon-import" title="Imported from Figgy" data-toggle="tooltip"></span>
         <% end %>
         <%= field.hidden_field :label, value: index_field_label(nil, key), class: 'form-control input-sm', data: {:"edit-field-target" => 'true'} %>
-       </div>
+      </div>
     </td>
+    <td class="checkbox-cell text-center"><%= field.check_box :text_area, inline: true, checked: config.text_area == "1", label: "", disabled: readonly?(key) %></td>
     <td class="checkbox-cell text-center"><%= field.check_box :show, inline: true, checked: config.show, label: "" %></td>
     <% available_view_fields.keys.each do |type| %>
-    <td class="checkbox-cell text-center"><%= field.check_box type, inline: true, checked: config.send(type), label: "" %></td>
+      <td class="checkbox-cell text-center"><%= field.check_box type, inline: true, checked: config.send(type), label: "" %></td>
     <% end %>
   <% end %>
 </tr>

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -10,6 +10,10 @@
       <thead>
         <tr>
           <th><%= t :'.fields.label' %></th>
+	  <th class="text-center">
+            <div>Text Area</div>
+            <%= select_deselect_button %>
+          </th>
           <th class="text-center">
             <div>
               <%= t :'.view.show', default: t(:'blacklight.search.view.show') %>

--- a/config/initializers/blacklight_initializer.rb
+++ b/config/initializers/blacklight_initializer.rb
@@ -4,3 +4,9 @@
 #
 
 # Blacklight.secret_key = '99d542f85bffaadb98670ae96ff5f860c910ede7fb262d48c345ff9d06d7d21ff5533bb8a26934f7067a24b2510f590d25bc6765c9cb02d56ec1e2c83dc78168'
+
+Blacklight::Rendering::Pipeline.operations = [Blacklight::Rendering::HelperMethod,
+                                              Blacklight::Rendering::LinkToFacet,
+                                              Blacklight::Rendering::Microdata,
+                                              Blacklight::Rendering::Join,
+                                              CustomFieldRendering]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   mount Blacklight::Engine => '/'
   root to: 'spotlight/exhibits#index'
   resources :exhibits, path: '/', only: [:create, :destroy]
+  match ':exhibit_id/metadata_configuration', to: 'pomegranate/metadata_configurations#update', via: [:patch, :put]
 
   # root to: "catalog#index" # replaced by spotlight root path
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/spec/controllers/pomegranate/metadata_configurations_controller_spec.rb
+++ b/spec/controllers/pomegranate/metadata_configurations_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe Pomegranate::MetadataConfigurationsController, type: :controller do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:user) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+
+  before { sign_in user }
+
+  describe 'PATCH update' do
+    it 'updates metadata fields' do
+      blacklight_config = Blacklight::Configuration.new
+      blacklight_config.add_index_field %w[a b c d e f]
+      allow(CatalogController).to receive_messages(blacklight_config: blacklight_config)
+      patch :update, params: {
+        exhibit_id: exhibit,
+        blacklight_configuration: {
+          index_fields: {
+            c: { enabled: true, show: true, text_area: "0" },
+            d: { enabled: true, show: true, text_area: "0" },
+            e: { enabled: true, list: true, text_area: "0" },
+            f: { enabled: true, list: true, text_area: "1" }
+          }
+        }
+      }
+
+      assigns[:exhibit].tap do |saved|
+        expect(saved.blacklight_configuration.index_fields).to include 'c', 'd', 'e', 'f'
+        expect(saved.blacklight_configuration.index_fields['c']).to include text_area: "0"
+        expect(saved.blacklight_configuration.index_fields['d']).to include text_area: "0"
+        expect(saved.blacklight_configuration.index_fields['e']).to include text_area: "0"
+        expect(saved.blacklight_configuration.index_fields['f']).to include text_area: "1"
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe ApplicationHelper, type: :helper do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:field) { instance_double(Spotlight::CustomField) }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+
+  before do
+    blacklight_config.index_fields['foo_tesim'] = OpenStruct.new('text_area' => "1")
+    allow(field).to receive(:field).and_return("foo_tesim")
+    allow(exhibit).to receive_messages(blacklight_config: blacklight_config)
+  end
+  describe '#text_area?' do
+    let(:output) { helper.text_area?(field, exhibit) }
+
+    it "determines whether or not a field should be rendered as a text_area" do
+      expect(output).to be true
+    end
+  end
+
+  describe '#text_area_value' do
+    let(:sidecar) { instance_double(Spotlight::SolrDocumentSidecar) }
+    let(:output) { helper.text_area_value(field, sidecar) }
+    let(:data) do
+      [{ type: "text", data: { text: "testing note", format: "html" } }]
+    end
+
+    before do
+      allow(sidecar).to receive(:data).and_return('foo_tesim' => { data: data })
+    end
+    it "normalizes the text area value" do
+      expect(output).to eq(data: data)
+    end
+  end
+end

--- a/spec/presenters/rtl_show_presenter_spec.rb
+++ b/spec/presenters/rtl_show_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RTLShowPresenter do
   let(:blacklight_config) do
     double(
       show_fields: { field:
-                    double(highlight: false, accessor: nil, default: nil, field: :field, helper_method: nil, link_to_search: nil, itemprop: nil, separator_options: nil, :separator_options= => nil) },
+                    double(highlight: false, accessor: nil, default: nil, field: :field, text_area: false, helper_method: nil, link_to_search: nil, itemprop: nil, separator_options: nil, :separator_options= => nil) },
       view_config: double(title_field: :title, html_title_field: nil)
     )
   end

--- a/spec/processors/custom_field_rendering_spec.rb
+++ b/spec/processors/custom_field_rendering_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CustomFieldRendering do
+  subject(:rendered) { custom_field_rendering.render }
+
+  let(:document) { instance_double(SolrDocument) }
+  let(:context) { double }
+  let(:options) { double }
+  let(:stack) { [Blacklight::Rendering::Terminator] }
+  let(:custom_field_rendering) do
+    described_class.new(values, field_config, document, context, options, stack)
+  end
+
+  describe "#render" do
+    let(:values) do
+      "{\"data\":[{\"type\":\"text\",\"data\":{\"text\":\"testing note\",\"format\":\"html\"}}]}"
+    end
+    let(:field_config) { Blacklight::Configuration::NullField.new(text_area: "1", separator_options: nil) }
+
+    it "parses the JSON and extracts the text" do
+      expect(rendered).to eq "testing note"
+    end
+
+    context "when the JSON is invalid" do
+      let(:values) do
+        "@#123"
+      end
+
+      it "renders the original string" do
+        expect(rendered).to eq values
+      end
+    end
+  end
+end


### PR DESCRIPTION
Overrides the MetadataConfiguration model and controller along with extending the Blacklight rendering pipeline.  Resolves #432 