### PR TITLE
Different page title and masthead title

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,6 +81,12 @@ class CatalogController < ApplicationController
     main_app.facet_catalog_url(*args)
   end
 
+  # search results
+  def index
+    @masthead_title = "Search Results"
+    super
+  end
+
   # get a single document from the index
   # to add responses for formats other than html or json see _Blacklight::Document::Export_
   def show

--- a/app/views/pages/viewers.html.erb
+++ b/app/views/pages/viewers.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Viewers" %>
+<% @masthead_title = "Viewers" %>
 <div class="container-fluid">
   <div class="col-xs-12 col-md-10">
     <h2>IIIF and Digital Object Viewers</h2>

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -7,7 +7,7 @@
     <span class='background-container-gradient'></span>
   <% end %>
 
-  <% if current_exhibit || content_for?(:masthead) || @page_title %>
+  <% if current_exhibit || content_for?(:masthead) || @masthead_title %>
     <div class="container site-title-container">
       <div class="site-title h1">
         <% if content_for? :masthead %>
@@ -18,8 +18,8 @@
           <% if @subtitle.present? %>
             <small dir='<%= @subtitle.dir %>'><%= @subtitle %></small>
           <% end %>
-        <% elsif @page_title %>
-          <%= @page_title %>
+        <% elsif @masthead_title %>
+          <%= @masthead_title %>
         <% end %>
       </div>
     </div>

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -1,3 +1,4 @@
+<% @masthead_title = application_name %>
 <div class="<%= "col-md-#{site_sidebar? ? 9 : 12}" %>">
   <% if (current_user && current_user.exhibits.any?) || can?(:manage, Spotlight::Exhibit) %>
     <ul class="nav nav-tabs" role="tablist">


### PR DESCRIPTION
Fixes #459 

* Restores masthead on home page
* Displays "Search Results" in the search results masthead, instead of (possibly JSON) search params