### PR TITLE
Making sure the correct fonts are used for li elements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -264,3 +264,7 @@ h2 {
 .modal-open {
  overflow: auto;
 }
+
+li {
+  font-family: $font-sans;
+}


### PR DESCRIPTION
Fixes #425 

There is probably a bigger SCSS issue here, but given that we're planning to revamp the design of the front page, and probably the fonts and usage of `pul-assets` in the near term, I thought a working fix was good enough.

