### PR TITLE
Extends the Spotlight::Exhibit Model for permitting the suppressing of thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Plum announces events to a durable RabbitMQ fanout exchange. In order to use the
 following:
 
 1. Configure the `events` settings in `config/config.yml`
-2. Run `WORKERS=PlumEventHandler rake sneakers:run`
+2. Run `WORKERS=FiggyEventHandler rake sneakers:run`
 
 This will subscribe to the plum events and update the pomegranate records when they're
 created, updated, or deleted.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,7 +62,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'spotlight_resource_type_ssim'
     config.add_facet_field 'readonly_collections_ssim', label: 'Collections', limit: 10
     config.add_index_field 'readonly_collections_ssim', label: 'Collections'
-    config.index.thumbnail_field = 'thumbnail_ssim'
+    config.index.thumbnail_method = :document_thumbnail
 
     config.add_facet_fields_to_solr_request!
     config.add_field_configuration_to_solr_request!

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -12,6 +12,20 @@ class ExhibitsController < Spotlight::ExhibitsController
     super
   end
 
+  protected
+
+    def exhibit_params
+      params.require(:exhibit).permit(
+        :title,
+        :subtitle,
+        :description,
+        :published,
+        :tag_list,
+        :thumbnails_enabled,
+        contact_emails_attributes: %i[id email]
+      )
+    end
+
   private
 
     def find_exhibit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,18 @@ module ApplicationHelper
 
     custom_field.readonly_field
   end
+
+  # Retrieve the thumbnail using the SolrDocument
+  # @param document [SolrDocument]
+  # @param image_options [Hash]
+  # @return [Array<String>] an Array containing the URLs to the thumbnails
+  def document_thumbnail(document, image_options = {})
+    return unless !current_exhibit.nil? && current_exhibit.thumbnails_enabled
+
+    values = document.fetch(:thumbnail_ssim, nil)
+    return if values.empty?
+
+    url = values.first
+    image_tag url, image_options if url.present?
+  end
 end

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -1,0 +1,30 @@
+
+<%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
+<div class="row col-md-12">
+  <%= f.text_field :title %>
+  <%= f.text_field :subtitle %>
+  <%= f.text_area :description %>
+  <%= f.text_field :tag_list, value: f.object.tag_list.to_s %>
+  <%= f.form_group(:contact_emails, label: { text: nil, class: nil }, help: nil) do %>
+    <%= f.fields_for :contact_emails do |contact| %>
+      <%= render partial: 'contact', locals: {exhibit: @exhibit, contact: contact} %>
+    <% end %>
+    <span id='another-email' class="btn btn-sm btn-info"><%= t('.add_contact_email_button') %></span>
+    <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
+  <% end %>
+  <%= f.form_group :thumbnails_enabled, label: { text: 'Display thumbnails?', class: nil }, help: nil do %>
+    <%= f.check_box :thumbnails_enabled, value: f.object.thumbnails_enabled, label: "" %>
+  <% end %>
+  <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>
+    <%= f.check_box :published, label: "" %>
+    <p class="help-block"><%= t(:'.fields.published.help_block') %></p>
+  <% end %>
+  
+  <div class="form-actions">
+    
+    <div class="primary-actions">
+      <%= f.submit nil, class: 'btn btn-primary' %>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   mount Blacklight::Engine => '/'
   root to: 'spotlight/exhibits#index'
-  resources :exhibits, path: '/', only: [:create, :destroy]
+  resources :exhibits, path: '/', only: [:create, :update, :destroy]
   match ':exhibit_id/metadata_configuration', to: 'pomegranate/metadata_configurations#update', via: [:patch, :put]
 
   # root to: "catalog#index" # replaced by spotlight root path

--- a/db/migrate/20190214151046_add_thumbnails_enabled_to_exhibits.rb
+++ b/db/migrate/20190214151046_add_thumbnails_enabled_to_exhibits.rb
@@ -1,0 +1,5 @@
+class AddThumbnailsEnabledToExhibits < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spotlight_exhibits, :thumbnails_enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180219235717) do
+ActiveRecord::Schema.define(version: 20190214151046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,21 +122,22 @@ ActiveRecord::Schema.define(version: 20180219235717) do
   end
 
   create_table "spotlight_exhibits", force: :cascade do |t|
-    t.string   "title",                          null: false
+    t.string   "title",                              null: false
     t.string   "subtitle"
     t.string   "slug"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "layout"
-    t.boolean  "published",      default: false
+    t.boolean  "published",          default: false
     t.datetime "published_at"
     t.string   "featured_image"
     t.integer  "masthead_id"
     t.integer  "thumbnail_id"
-    t.integer  "weight",         default: 50
+    t.integer  "weight",             default: 50
     t.integer  "site_id"
     t.string   "theme"
+    t.boolean  "thumbnails_enabled", default: true
     t.index ["site_id"], name: "index_spotlight_exhibits_on_site_id", using: :btree
     t.index ["slug"], name: "index_spotlight_exhibits_on_slug", unique: true, using: :btree
   end

--- a/spec/controllers/exhibits_controller_spec.rb
+++ b/spec/controllers/exhibits_controller_spec.rb
@@ -50,6 +50,30 @@ RSpec.describe ExhibitsController, vcr: { cassette_name: "all_collections", allo
     end
   end
 
+  describe '#update' do
+    let(:exhibit) { Spotlight::Exhibit.new(title: 'New Collection', published: true, slug: 'new-collection') }
+    let(:params) do
+      {
+        title: 'Some Title',
+        thumbnails_enabled: false,
+        tag_list: '2014, R. Buckminster Fuller'
+      }
+    end
+
+    before do
+      exhibit.save
+    end
+
+    it 'disables the rendering of thumbnails' do
+      exhibit.reload
+      expect(exhibit.thumbnails_enabled).to be true
+      patch :update, params: { id: exhibit, exhibit: params }
+
+      exhibit.reload
+      expect(exhibit.thumbnails_enabled).to be false
+    end
+  end
+
   describe "#destroy" do
     let(:exhibit) do
       {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,4 +53,32 @@ describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#document_thumbnail' do
+    let(:exhibit) { instance_double(Spotlight::Exhibit) }
+    let(:document) { instance_double(SolrDocument) }
+    let(:thumbnail_url) { 'https://images.institution.edu/image-server/prefix/id%2Fintermediate_file.jp2/full/!200,150/0/default.jpg' }
+    let(:output) { helper.document_thumbnail(document) }
+
+    before do
+      allow(helper).to receive(:current_exhibit).and_return(exhibit)
+      allow(document).to receive(:fetch).with(:thumbnail_ssim, nil).and_return([thumbnail_url])
+    end
+
+    it 'generates an <img> element for SolrDocument thumbnails when Exhibits are configured to display them' do
+      allow(exhibit).to receive(:thumbnails_enabled).and_return(true)
+
+      expect(output).to eq("<img src=\"#{thumbnail_url}\" alt=\"Default\" />")
+    end
+
+    context 'when thumbnails are disabled for the exhibit' do
+      before do
+        allow(exhibit).to receive(:thumbnails_enabled).and_return(false)
+      end
+
+      it 'suppresses the thumbnails and does not generate markup' do
+        expect(output).to be nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #475 by addressing the following:
- Extends the Spotlight::Exhibit Model for permitting the suppressing of thumbnails (from within the "General" configuration interface)
- Provides a thumbnail retrieval method within the CatalogController (this was necessary in order to determine whether or not the Exhibit suppresses thumbnail displays)
- Fixes the sneakers command in the README (`PlumEventHandler` no has been renamed `FiggyEventHandler`)