### PR TITLE
Overrides the ApplicationHelper#application_name method in order to use only the site branding

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,7 @@ module ApplicationHelper
   def header_title
     site_title || t("blacklight.application_name")
   end
+  alias application_name header_title
 
   def current_year
     Date.today.year

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -54,6 +54,20 @@ describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#application_name' do
+    let(:current_site) { instance_double(Spotlight::Site) }
+
+    before do
+      allow(helper).to receive(:current_site).and_return(current_site)
+      allow(current_site).to receive(:title).and_return('Test Site Title')
+    end
+
+    it 'delegates to the #application_name for the Spotlight::Site' do
+      expect(helper.application_name).to eq 'Test Site Title'
+      expect(helper.application_name).to eq helper.header_title
+    end
+  end
+
   describe '#document_thumbnail' do
     let(:exhibit) { instance_double(Spotlight::Exhibit) }
     let(:document) { instance_double(SolrDocument) }


### PR DESCRIPTION
Resolves #518 