### PR TITLE
Handles cases where the view_context cannot be used to generate collection links in the RTLShowPresenter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,7 @@ RSpec/ExampleLength:
     - 'spec/services/figgy_event_processor_spec.rb'
     - 'spec/workers/figgy_event_handler_spec.rb'
     - 'spec/requests/catalog_spec.rb'
+    - 'spec/features/catalog_show_spec.rb'
 
 RSpec/ExampleWording:
   CustomTransform:
@@ -165,3 +166,4 @@ Naming/FileName:
 RSpec/AnyInstance:
   Exclude:
     - 'spec/support/stub_iiif_response.rb'
+    - 'spec/features/catalog_show_spec.rb'

--- a/app/presenters/rtl_show_presenter.rb
+++ b/app/presenters/rtl_show_presenter.rb
@@ -29,6 +29,10 @@ class RTLShowPresenter < ::Blacklight::ShowPresenter
   def collection_value(value)
     collection = Spotlight::Exhibit.where(title: value).first
     return value unless collection
+    unless view_context.respond_to?(:exhibit_root_path)
+      Rails.logger.error "Failed to render the link to the collection #{value} for #{collection.id}"
+      return value
+    end
     link_to collection.title, view_context.exhibit_root_path(collection)
   end
 


### PR DESCRIPTION
Resolves #522 