### PR TITLE
Handles cases in ApplicationHelper#document_thumbnail when document manifest URLs cannot be retrieved

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   include Blacklight::BlacklightHelperBehavior
   include Spotlight::ApplicationHelper
-  delegate :url, to: :request, prefix: true
+  delegate :url, to: :universal_viewer, prefix: true
 
   def render_search_bar
     super
@@ -52,7 +52,7 @@ module ApplicationHelper
   # @param image_options [Hash]
   # @return [Array<String>] an Array containing the URLs to the thumbnails
   def document_thumbnail(document, image_options = {})
-    return unless !current_exhibit.nil? && current_exhibit.thumbnails_enabled
+    return unless !current_exhibit.nil? && current_exhibit.thumbnails_enabled && !universal_viewer.nil?
 
     values = document.fetch(:thumbnail_ssim, nil)
     return if values.empty?
@@ -60,11 +60,6 @@ module ApplicationHelper
     url = values.first
     image_tag url, image_options if url.present?
   end
-
-  # Generate the URL for the Universal Viewer to view the content for the
-  # document manifest
-  # @return [String]
-  delegate :url, to: :universal_viewer, prefix: true
 
   private
 
@@ -84,6 +79,8 @@ module ApplicationHelper
     # Construct the object used to handle Universal Viewer installations
     # @return [UniversalViewer]
     def universal_viewer
+      return if @document.nil?
+
       UniversalViewer.new(
         universal_viewer_installation_url,
         manifest: @document.manifest,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -73,16 +73,28 @@ describe ApplicationHelper, type: :helper do
     let(:document) { instance_double(SolrDocument) }
     let(:thumbnail_url) { 'https://images.institution.edu/image-server/prefix/id%2Fintermediate_file.jp2/full/!200,150/0/default.jpg' }
     let(:output) { helper.document_thumbnail(document) }
+    let(:manifest) {
+      "https://repository.institution.edu/concern/scanned_resources/cfd8cb11-660f-4f12-92f6-fb2b22995028/manifest"
+    }
 
     before do
       allow(helper).to receive(:current_exhibit).and_return(exhibit)
       allow(document).to receive(:fetch).with(:thumbnail_ssim, nil).and_return([thumbnail_url])
+      allow(document).to receive(:manifest).and_return(manifest)
+      assign(:document, document)
+      allow(exhibit).to receive(:thumbnails_enabled).and_return(true)
     end
 
     it 'generates an <img> element for SolrDocument thumbnails when Exhibits are configured to display them' do
-      allow(exhibit).to receive(:thumbnails_enabled).and_return(true)
-
       expect(output).to eq("<img src=\"#{thumbnail_url}\" alt=\"Default\" />")
+    end
+
+    context 'when the document cannot be retrieved' do
+      let(:document) { nil }
+
+      it 'does not generate any markup' do
+        expect(output).to be nil
+      end
     end
 
     context 'when thumbnails are disabled for the exhibit' do


### PR DESCRIPTION
Resolves #575 