### PR TITLE
Remove stale information from sidecar.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+    - 'app/services/iiif_manifest.rb'
 
 Metrics/MethodLength:
   Enabled: false

--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -2,7 +2,7 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
   def to_solr
     add_noid
     # this is called in super, but idempotent so safe to call here also; we need the metadata
-    add_metadata
+    solr_hash.merge!(manifest_metadata)
     add_sort_title
     add_sort_date
     add_sort_author
@@ -57,6 +57,14 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
     else
       /.*\/(.*)\/manifest/.match(url)[1]
     end
+  end
+
+  def add_metadata
+    solr_hash.merge!(manifest_metadata)
+    sidecar.data = sidecar.data.reject do |k, _v|
+      k.to_s.start_with?("readonly")
+    end
+    sidecar.update(data: sidecar.data.merge(manifest_metadata))
   end
 
   def manifest_metadata

--- a/spec/fixtures/metadata/12345678-changed.json
+++ b/spec/fixtures/metadata/12345678-changed.json
@@ -1,0 +1,34 @@
+{  
+  "@context":"http://bibdata.princeton.edu/context.json",
+  "@id":"http://bibdata.princeton.edu/bibliographic/1234567",
+  "title":[  
+    "Christopher and his kind, 1929-1939"
+  ],
+  "description":[  
+    "First",
+    "Second"
+  ],
+  "language":"eng",
+  "call_number":"PR6017.S5 Z498",
+  "extent":"339 p. ; 22 cm.",
+  "edition":"1st ed.",
+  "format":"Book",
+  "genre":"Biography",
+  "publisher":"New York : Farrar, Straus Giroux, 1976.",
+  "subject":[  
+    "Isherwood, Christopher, 1904-1986",
+    "Authors, English—20th century—Biography"
+  ],
+  "donor":[  
+    "Copland, Aaron, 1900-1990"
+  ],
+  "author":"Isherwood, Christopher, 1904-1986",
+  "created":"1976-01-01T00:00:00Z",
+  "date":"1976",
+  "memberOf":[  
+    {  
+      "@id":"https://plum.princeton.edu/collections/pw9505t09q",
+      "title":"East Asian Library Digital Bookshelf"
+    }
+  ]
+}

--- a/spec/support/stub_manifests.rb
+++ b/spec/support/stub_manifests.rb
@@ -6,9 +6,9 @@ module StubbedManifestsHelper
       .to_return(status: status, body: File.read(Rails.root.join("spec", "fixtures", "manifests", fixture)), headers: { 'content-type' => 'application/ld+json' })
   end
 
-  def stub_metadata(id:, status: 200)
+  def stub_metadata(id:, status: 200, fixture: nil)
     stub_request(:get, "https://figgy.princeton.edu/catalog/#{id}.jsonld")
-      .to_return(status: status, body: File.read(Rails.root.join("spec", "fixtures", "metadata", "#{id}.json")), headers: { 'content-type' => 'application/ld+json' })
+      .to_return(status: status, body: File.read(Rails.root.join("spec", "fixtures", "metadata", "#{fixture || id}.json")), headers: { 'content-type' => 'application/ld+json' })
   end
 
   def stub_ocr_content(id:, text:)


### PR DESCRIPTION
The sidecar is used for atomic metadata updates, but it's not being kept
in sync with removals from the solr document. This should refresh those
removals appropriately, fixing issues with strange metadata showing up
in records.