### PR TITLE
Make word breaks work even on single values.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -234,7 +234,7 @@ li[dir=rtl] {
 .tab-content {
   padding: 1em .1em;
 }
-.dl-horizontal dd ul {
+.document-metadata.dl-horizontal dd {
   word-break: normal;
 }
 dd {


### PR DESCRIPTION
Items don't get wrapped in a ul if there's only one entry, so this CSS
wasn't applying.

Closes #602

<img width="941" alt="Screen Shot 2019-09-12 at 9 33 23 AM" src="https://user-images.githubusercontent.com/2806645/64802833-658eee80-d540-11e9-9a45-da32dbb9a056.png">
