### PR TITLE
Use environment specific retry queue.

### DIFF
--- a/app/workers/figgy_event_handler.rb
+++ b/app/workers/figgy_event_handler.rb
@@ -2,7 +2,7 @@ class FiggyEventHandler
   include Sneakers::Worker
   from_queue :"pomegranate_#{Rails.env}",
              WORKER_OPTIONS.merge(
-               arguments: { 'x-dead-letter-exchange': 'pomegranate-retry' }
+               arguments: { 'x-dead-letter-exchange': "pomegranate_#{Rails.env}-retry" }
              )
 
   def work(msg)

--- a/spec/workers/figgy_event_handler_spec.rb
+++ b/spec/workers/figgy_event_handler_spec.rb
@@ -35,5 +35,8 @@ RSpec.describe FiggyEventHandler do
       expect(FiggyEventProcessor).to have_received(:new).with(msg)
       expect(handler).to have_received(:ack!)
     end
+    it "is configured to use an environment specific deadletter queue" do
+      expect(described_class.queue_opts[:arguments][:"x-dead-letter-exchange"]).to eq "pomegranate_test-retry"
+    end
   end
 end


### PR DESCRIPTION
Closes #580 

The issue was it was dead-lettering to an exchange with no bound queues, because everything's set up for an environment specific queue.