### PR TITLE
Fix missing Text Area header in metadata config.

### DIFF
--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -11,6 +11,10 @@
         <tr>
           <th><%= t :'.field.label' %></th>
           <th class="text-center">
+            <div>Text Area</div>
+            <%= select_deselect_button %>
+          </th>
+          <th class="text-center">
             <div>
               <%= t :'.view.show' %>
             </div>

--- a/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
@@ -13,11 +13,10 @@ describe 'spotlight/metadata_configurations/edit', type: :view do
     )
     Spotlight::CustomField.create!(exhibit: exhibit, slug: "one", field: "one", label: "one", field_type: "vocab", readonly_field: false)
     Spotlight::CustomField.create!(exhibit: exhibit, slug: "two", field: "two", label: "two", field_type: "vocab", readonly_field: true)
+    render
   end
 
   it "displays only writeable custom fields" do
-    render
-
     within "#exhibit-specific-fields" do
       expect(rendered).to have_content "one"
       expect(rendered).not_to have_content "two"

--- a/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
@@ -21,6 +21,7 @@ describe 'spotlight/metadata_configurations/edit', type: :view do
     within "#exhibit-specific-fields" do
       expect(rendered).to have_content "one"
       expect(rendered).not_to have_content "two"
+      expect(rendered).to have_selector "th", text: "Text Area"
     end
   end
 end


### PR DESCRIPTION
This got missed in the Spotlight upgrade.