### PR TITLE
Generalize word-break styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -234,7 +234,7 @@ li[dir=rtl] {
 .tab-content {
   padding: 1em .1em;
 }
-.document-metadata.dl-horizontal dd {
+.dl-horizontal dd {
   word-break: normal;
 }
 dd {


### PR DESCRIPTION
I'm not sure why this additional class was added in https://github.com/pulibrary/pomegranate/pull/604/files. Removing it fixes word wrap on the show page and retains the fix on the search results page. @tpendragon do you have any recollection of why it was added?

fixes #674

Before:
![Screen Shot 2020-01-21 at 1 00 32 PM](https://user-images.githubusercontent.com/845363/72830238-4ae72780-3c4e-11ea-88fb-e5625ce93892.png)

After:
![Screen Shot 2020-01-21 at 1 00 19 PM](https://user-images.githubusercontent.com/845363/72830250-4e7aae80-3c4e-11ea-99ae-8f5e5e020aac.png)
