### PR TITLE
Move reindexing logic to IIIFResource.

### DIFF
--- a/app/models/iiif_resource.rb
+++ b/app/models/iiif_resource.rb
@@ -66,7 +66,7 @@ class IIIFResource < Spotlight::Resources::IiifHarvester
     # resource so we can keep the hidden fields that might have been set up in
     # DPUL, but we also don't want them to show up in search results.
     def remove_hidden_solr_records
-      return unless iiif_manifests.to_a.blank?
+      return if iiif_manifests.to_a.present?
       doc = SolrDocument.find(noid, exhibit: exhibit)
       solr.delete_by_id(doc.id, params: { softCommit: true })
     end

--- a/app/models/iiif_resource.rb
+++ b/app/models/iiif_resource.rb
@@ -39,12 +39,37 @@ class IIIFResource < Spotlight::Resources::IiifHarvester
     data["noid"]
   end
 
+  # We have to override both save_and_index and save_and_index_now instead of
+  # just reindex because they call `save && reindex`, and sometimes there's
+  # nothing new to save so it returns false - yet we still want it to remove
+  # hidden solr records.
+  def save_and_index(*args)
+    remove_hidden_solr_records
+    super
+  end
+
   def save_and_index_now(*args)
     save(*args)
+    remove_hidden_solr_records
     Spotlight::ReindexJob.perform_now(self)
   end
 
+  def reindex(*args)
+    return if exhibit.nil?
+    super
+  end
+
   private
+
+    # Hidden solr records are records for resources in Figgy which have been
+    # given a status such as "Takedown" or "Private". We don't want to delete the
+    # resource so we can keep the hidden fields that might have been set up in
+    # DPUL, but we also don't want them to show up in search results.
+    def remove_hidden_solr_records
+      return unless iiif_manifests.to_a.blank?
+      doc = SolrDocument.find(noid, exhibit: exhibit)
+      solr.delete_by_id(doc.id, params: { softCommit: true })
+    end
 
     def set_noid
       data["noid"] = iiif_manifests.first.noid

--- a/app/services/figgy_event_processor/processor.rb
+++ b/app/services/figgy_event_processor/processor.rb
@@ -24,9 +24,5 @@ class FiggyEventProcessor
       def event_type
         event["event"]
       end
-
-      def index
-        Blacklight.default_index.connection
-      end
   end
 end

--- a/app/services/figgy_event_processor/update_processor.rb
+++ b/app/services/figgy_event_processor/update_processor.rb
@@ -10,15 +10,11 @@ class FiggyEventProcessor
     end
 
     def delete_old_resources
-      delete_resources.each do |resource|
-        resource.destroy
-      end
+      delete_resources.each(&:destroy)
     end
 
     def update_existing_resources
-      IIIFResource.where(url: manifest_url).each do |resource|
-        resource.save_and_index
-      end
+      IIIFResource.where(url: manifest_url).each(&:save_and_index)
     end
 
     def create_new_resources

--- a/app/services/figgy_event_processor/update_processor.rb
+++ b/app/services/figgy_event_processor/update_processor.rb
@@ -11,30 +11,13 @@ class FiggyEventProcessor
 
     def delete_old_resources
       delete_resources.each do |resource|
-        resource.document_builder.to_solr.map { |x| x[:id] }.each do |id|
-          index.delete_by_id id.to_s
-        end
         resource.destroy
       end
     end
 
     def update_existing_resources
       IIIFResource.where(url: manifest_url).each do |resource|
-        begin
-          # Make solr document private if it's no longer valid.
-          next if resource.exhibit.blank?
-          document = SolrDocument.find(resource.noid, exhibit: resource.exhibit)
-          resource.save_and_index
-          if resource.document_builder.documents_to_index.to_a.empty?
-            document.make_private!(resource.exhibit)
-          else
-            document.make_public!(resource.exhibit)
-          end
-
-          document.save
-        rescue Blacklight::Exceptions::RecordNotFound
-          Rails.logger.warn("Unable to find Solr record: #{resource.noid}")
-        end
+        resource.save_and_index
       end
     end
 

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -349,6 +349,10 @@ describe IIIFResource do
       before do
         allow(Spotlight::ReindexJob).to receive(:perform_now)
         allow(resource).to receive(:save)
+        stub_manifest(
+          url: url,
+          fixture: "vol1.json"
+        )
       end
 
       it 'calls perform now on Spotlight::ReindexJob' do


### PR DESCRIPTION
This deletes Solr Records when the manifest is gone and also makes it so
the IIIFResource reindexing logic handles that.

Closes #635 and Closes #684