### PR TITLE
Capture record not found if a record's never been indexed.

### DIFF
--- a/app/models/iiif_resource.rb
+++ b/app/models/iiif_resource.rb
@@ -69,6 +69,8 @@ class IIIFResource < Spotlight::Resources::IiifHarvester
       return if iiif_manifests.to_a.present?
       doc = SolrDocument.find(noid, exhibit: exhibit)
       solr.delete_by_id(doc.id, params: { softCommit: true })
+    rescue Blacklight::Exceptions::RecordNotFound
+      Rails.logger.debug "No solr record for #{noid} to delete."
     end
 
     def set_noid


### PR DESCRIPTION
This is necessary for a fresh reindex.