### PR TITLE
Pin Pul-Assets gem to the version that works.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,6 @@ gem 'webpacker', '>= 4.0.x'
 gem 'dalli'
 gem 'honeybadger', '~> 2.0'
 gem 'nokogiri', '~> 1.10.7'
-gem 'pul-assets', github: 'pulibrary/pul_assets'
+gem 'pul-assets', github: 'pulibrary/pul_assets', ref: '84dc633f5ff39167b4f7e7acf2517fffda630f0f'
 gem 'ruby-prof', require: false
 gem 'rubyzip', '>= 1.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,12 +44,12 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/pul_assets.git
-  revision: 0947abe3d47e0e1581fdbdeea25b28bc47cae29a
+  revision: 84dc633f5ff39167b4f7e7acf2517fffda630f0f
+  ref: 84dc633f5ff39167b4f7e7acf2517fffda630f0f
   specs:
     pul-assets (0.2.2)
       bourbon (~> 4.2.6)
       breakpoint (~> 2.7.0)
-      jquery-datatables-rails (~> 3.4.0)
       jquery-tablesorter (~> 1.20.5)
       modernizr-rails (~> 2.7.1)
       normalize-rails (~> 3.0.3)
@@ -273,11 +273,6 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
-    jquery-datatables-rails (3.4.0)
-      actionpack (>= 3.1)
-      jquery-rails
-      railties (>= 3.1)
-      sass-rails
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)


### PR DESCRIPTION
The new version of the gem is updated for Orangelight's Blacklight 7
upgrade.

Closes #746 