### PR TITLE
Allow external users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,8 +25,15 @@ class User < ActiveRecord::Base
 
   def set_cas_defaults
     self.provider = "cas"
-    self.username = email.gsub(/@.*/, '')
+    self.username = default_username
     self.uid = username
+  end
+
+  def default_username
+    username, domain = email.split('@')
+    return username if domain == "princeton.edu"
+
+    email
   end
 
   def self.from_omniauth(access_token)
@@ -34,8 +41,14 @@ class User < ActiveRecord::Base
       user.uid = access_token.uid
       user.provider = access_token.provider
       user.username = access_token.uid
-      user.email = "#{access_token.uid}@princeton.edu"
+      user.email = initialize_email(access_token.uid)
     end
+  end
+
+  def self.initialize_email(uid)
+    return uid if /@/.match?(uid)
+
+    "#{uid}@princeton.edu"
   end
 
   # No reason to ever send invites, because of CAS.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,31 +10,70 @@ RSpec.describe User do
   end
 
   describe ".from_omniauth" do
-    let(:token) { OmniAuth::AuthHash::InfoHash.new(provider: "cas", uid: "test") }
-    let(:user) { described_class.from_omniauth(token) }
+    context "with a campus user" do
+      let(:token) { OmniAuth::AuthHash::InfoHash.new(provider: "cas", uid: "test") }
+      let(:user) { described_class.from_omniauth(token) }
 
-    it "creates a persisted user" do
-      expect(user).to be_persisted
+      it "creates a persisted user" do
+        expect(user).to be_persisted
+      end
+      it "has a cas provider" do
+        expect(user.provider).to eq "cas"
+      end
+      it "has a uid" do
+        expect(user.uid).to eq "test"
+      end
+      it "has a username" do
+        expect(user.username).to eq "test"
+      end
+      it "creates an email address based on netid" do
+        expect(user.email).to eq("test@princeton.edu")
+      end
+      it "doesn't make them an administrator" do
+        expect(user.roles).to eq []
+      end
     end
-    it "has a cas provider" do
-      expect(user.provider).to eq "cas"
-    end
-    it "has a uid" do
-      expect(user.uid).to eq "test"
-    end
-    it "has a username" do
-      expect(user.username).to eq "test"
-    end
-    it "doesn't make them an administrator" do
-      expect(user.roles).to eq []
+
+    context "with an external user" do
+      let(:token) { OmniAuth::AuthHash::InfoHash.new(provider: "cas", uid: "test@example.com") }
+      let(:user) { described_class.from_omniauth(token) }
+
+      it "creates a persisted user" do
+        expect(user).to be_persisted
+      end
+      it "has a cas provider" do
+        expect(user.provider).to eq "cas"
+      end
+      it "has a uid" do
+        expect(user.uid).to eq "test@example.com"
+      end
+      it "has a username" do
+        expect(user.username).to eq "test@example.com"
+      end
+      it "has email equal to uid" do
+        expect(user.email).to eq("test@example.com")
+      end
+      it "doesn't make them an administrator" do
+        expect(user.roles).to eq []
+      end
     end
   end
 
-  it "can invite users" do
-    expect { described_class.invite!(email: 'a-user-that-does-not-exist@princeton.edu', skip_invitation: true) }.not_to raise_error
-    expect(described_class.last.provider).to eq "cas"
-    expect(described_class.last.uid).to eq "a-user-that-does-not-exist"
-    expect(described_class.last.username).to eq "a-user-that-does-not-exist"
-    expect(described_class.last.invite_pending?).to eq false
+  describe "inviting users" do
+    it "can invite campus users" do
+      expect { described_class.invite!(email: 'a-user-that-does-not-exist@princeton.edu', skip_invitation: true) }.not_to raise_error
+      expect(described_class.last.provider).to eq "cas"
+      expect(described_class.last.uid).to eq "a-user-that-does-not-exist"
+      expect(described_class.last.username).to eq "a-user-that-does-not-exist"
+      expect(described_class.last.invite_pending?).to eq false
+    end
+
+    it "can invite external users" do
+      expect { described_class.invite!(email: 'new-user@example.com', skip_invitation: true) }.not_to raise_error
+      expect(described_class.last.provider).to eq "cas"
+      expect(described_class.last.uid).to eq "new-user@example.com"
+      expect(described_class.last.username).to eq "new-user@example.com"
+      expect(described_class.last.invite_pending?).to eq false
+    end
   end
 end


### PR DESCRIPTION
Their uid and username are both their email address. princeton.edu is no
longer appended to make the email address if the uid is already an email address.

This should be deployed to staging and tested.

Once it's deployed to prod the user account in question needs to be fixed up. One account should be deleted and the other should be repaired. user ids are 126034 and 127463.

progresses #750 