### PR TITLE
Factories stub the figgy_uuid; rename from source_metadata_identifier

### DIFF
--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BookmarksController do
         url: "https://figgy.princeton.edu/concern/scanned_resources/beaec815-6a34-4519-8ce8-40a89d3b1956/manifest",
         exhibit: exhibit,
         manifest_fixture: "paris_map.json",
-        source_metadata_identifier: "beaec815-6a34-4519-8ce8-40a89d3b1956",
+        figgy_uuid: "beaec815-6a34-4519-8ce8-40a89d3b1956",
         spec: self
       )
 
@@ -29,7 +29,7 @@ RSpec.describe BookmarksController do
         url: "https://figgy.princeton.edu/concern/scanned_resources/0cc43bdb-ae21-47b2-90bc-bc21a18ee821/manifest",
         exhibit: exhibit,
         manifest_fixture: "chinese_medicine.json",
-        source_metadata_identifier: "0cc43bdb-ae21-47b2-90bc-bc21a18ee821",
+        figgy_uuid: "0cc43bdb-ae21-47b2-90bc-bc21a18ee821",
         spec: self
       )
 

--- a/spec/factories/iiif_resource.rb
+++ b/spec/factories/iiif_resource.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     transient do
       # Fixture to use for stubbing the manifest.
       manifest_fixture { nil }
-      # Source metadata identifier to stub out
-      source_metadata_identifier { nil }
+      # figgy id to stub out
+      figgy_uuid { nil }
       # Stubbed OCR content
       stubbed_ocr_content { nil }
       # Reference to the spec to enable the factory to stub out requests.
@@ -16,8 +16,8 @@ FactoryBot.define do
     before(:create) do |resource, evaluator|
       if evaluator.spec.present?
         evaluator.spec.stub_manifest(url: resource.url, fixture: evaluator.manifest_fixture) if evaluator.manifest_fixture
-        evaluator.spec.stub_metadata(id: evaluator.source_metadata_identifier) if evaluator.source_metadata_identifier
-        evaluator.spec.stub_ocr_content(id: evaluator.source_metadata_identifier, text: evaluator.stubbed_ocr_content) if evaluator.source_metadata_identifier && evaluator.stubbed_ocr_content
+        evaluator.spec.stub_metadata(id: evaluator.figgy_uuid) if evaluator.figgy_uuid
+        evaluator.spec.stub_ocr_content(id: evaluator.figgy_uuid, text: evaluator.stubbed_ocr_content) if evaluator.figgy_uuid && evaluator.stubbed_ocr_content
       end
     end
 

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Bookmarks', type: :feature, js: true do
     url: "https://figgy.princeton.edu/concern/scanned_resources/beaec815-6a34-4519-8ce8-40a89d3b1956/manifest",
     exhibit: exhibit,
     manifest_fixture: "paris_map.json",
-    source_metadata_identifier: "beaec815-6a34-4519-8ce8-40a89d3b1956",
+    figgy_uuid: "beaec815-6a34-4519-8ce8-40a89d3b1956",
     spec: self
   )
   end
@@ -18,7 +18,7 @@ RSpec.describe 'Bookmarks', type: :feature, js: true do
     url: "https://figgy.princeton.edu/concern/scanned_resources/0cc43bdb-ae21-47b2-90bc-bc21a18ee821/manifest",
     exhibit: exhibit,
     manifest_fixture: "chinese_medicine.json",
-    source_metadata_identifier: "0cc43bdb-ae21-47b2-90bc-bc21a18ee821",
+    figgy_uuid: "0cc43bdb-ae21-47b2-90bc-bc21a18ee821",
     spec: self
   )
   end

--- a/spec/views/spotlight/sir_trevor/blocks/_recent_items_block.html.erb_spec.rb
+++ b/spec/views/spotlight/sir_trevor/blocks/_recent_items_block.html.erb_spec.rb
@@ -28,7 +28,7 @@ describe 'spotlight/sir_trevor/blocks/_recent_items_block.html.erb', type: :view
       url: "https://hydra-dev.princeton.edu/concern/scanned_resources/e41da87f-84af-4f50-ab69-781576cf82db/manifest",
       exhibit: exhibit,
       manifest_fixture: "full_text_manifest.json",
-      source_metadata_identifier: "e41da87f-84af-4f50-ab69-781576cf82db",
+      figgy_uuid: "e41da87f-84af-4f50-ab69-781576cf82db",
       stubbed_ocr_content: "More searchable text",
       spec: self
     )
@@ -38,7 +38,7 @@ describe 'spotlight/sir_trevor/blocks/_recent_items_block.html.erb', type: :view
       url: "https://figgy-staging.princeton.edu/concern/scanned_maps/fffdaa09-b0c6-4ba3-8fe5-de6b13bd3d5f/manifest",
       exhibit: exhibit,
       manifest_fixture: "map.json",
-      source_metadata_identifier: "fffdaa09-b0c6-4ba3-8fe5-de6b13bd3d5f",
+      figgy_uuid: "fffdaa09-b0c6-4ba3-8fe5-de6b13bd3d5f",
       spec: self
     )
     # Modified Date isn't defined; has thumbnail
@@ -55,7 +55,7 @@ describe 'spotlight/sir_trevor/blocks/_recent_items_block.html.erb', type: :view
       url: "https://figgy.princeton.edu/concern/scanned_resources/965238bf-7850-4ae2-8830-f709c0f1b732/manifest",
       exhibit: exhibit,
       manifest_fixture: "no_thumbnail.json",
-      source_metadata_identifier: "965238bf-7850-4ae2-8830-f709c0f1b732",
+      figgy_uuid: "965238bf-7850-4ae2-8830-f709c0f1b732",
       spec: self
     )
   end


### PR DESCRIPTION
It looks like we were initially using the `source_metadata_identifier` as the filename for these fixtures, but at some point moved to using the uuid and now the label is misleading.