### PR TITLE
Report noid in indexing error

### DIFF
--- a/app/models/iiif_resource.rb
+++ b/app/models/iiif_resource.rb
@@ -94,6 +94,12 @@ class IIIFResource < Spotlight::Resources::IiifHarvester
       document_builder.documents_to_index.to_a.map { |y| y[:id] }
     end
 
+    # If the document is being reindexed, it will have a noid. Reporting the
+    # noid makes it easier to find
+    def document_ids_with_noids
+      document_builder.documents_to_index.to_a.map { |y| "(id: #{y[:id]}, noid: #{noid})" }
+    end
+
     def write_to_index(batch)
       documents = documents_that_have_ids(batch)
       return unless write? && documents.present?
@@ -101,7 +107,7 @@ class IIIFResource < Spotlight::Resources::IiifHarvester
       blacklight_solr.update data: documents.to_json,
                              headers: { 'Content-Type' => 'application/json' }
     rescue RSolr::Error::Http
-      error_message = "Failed to update Solr for the following documents: #{document_ids.join(', ')}"
+      error_message = "Failed to update Solr for the following documents: #{document_ids_with_noids.join(', ')}"
       Rails.logger.error error_message
       raise IndexingError, error_message
     end

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -460,17 +460,15 @@ describe IIIFResource do
         let(:request) { double }
         let(:response) { double }
         let(:rsolr_error) { RSolr::Error::Http.new(request, response) }
-        let(:ids) do
-          docs = resource.document_builder.documents_to_index
-          docs.map { |document| document[:id] }
-        end
-        let(:error_message) { "Failed to update Solr for the following documents: #{ids.join(', ')}" }
-
-        before do
-          allow(blacklight_solr).to receive(:update).and_raise(rsolr_error)
-        end
 
         it 'logs an error' do
+          # Save it first to ensure the noid is in place to be reported
+          resource.save_and_index
+          resource_id = resource.document_builder.documents_to_index.first[:id]
+          ids = "(id: #{resource_id}, noid: #{resource.noid})"
+          error_message = "Failed to update Solr for the following documents: #{ids}"
+
+          allow(blacklight_solr).to receive(:update).and_raise(rsolr_error)
           expect { resource.reindex }.to raise_error(IIIFResource::IndexingError, error_message)
         end
       end


### PR DESCRIPTION
Makes resources that failed to reindex easier to find.
fixes #710