### PR TITLE
Skip solr cleanup when the document can't be created

### DIFF
--- a/app/models/iiif_resource.rb
+++ b/app/models/iiif_resource.rb
@@ -32,6 +32,8 @@ class IIIFResource < Spotlight::Resources::IiifHarvester
   end
 
   def cleanup_solr
+    return unless document_model
+
     solr.delete_by_id(document_ids, params: { softCommit: true })
   end
 


### PR DESCRIPTION
Handles the case where a resource doesn't have an exhibit (or had an
exhibit that was deleted)

fixes #785