### PR TITLE
Delete orphan resources on rabbit update event

### DIFF
--- a/app/services/figgy_event_processor/processor.rb
+++ b/app/services/figgy_event_processor/processor.rb
@@ -18,7 +18,8 @@ class FiggyEventProcessor
       end
 
       def collection_slugs
-        event["collection_slugs"]
+        # it can be nil in the event, ensure it always returns an array
+        Array.wrap(event["collection_slugs"])
       end
 
       def event_type

--- a/spec/services/figgy_event_processor_spec.rb
+++ b/spec/services/figgy_event_processor_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe FiggyEventProcessor do
       end
     end
 
+    context "when there are no collection_slugs in the event" do
+      let(:event) do
+        {
+          "id" => "1r66j1149",
+          "event" => type,
+          "manifest_url" => url
+        }
+      end
+
+      it "doesn't blow up" do
+        expect(processor.process).to eq true
+      end
+    end
+
     context "when it's no longer accessible" do
       it "deletes it from solr, but leaves it in the DB" do
         exhibit = FactoryBot.create(:exhibit, slug: "first")


### PR DESCRIPTION
Draft status due to dependence on #795. This can be taken out of draft (change base to master) if that one is merged.

fixes #784