### PR TITLE
Make staging queues non-durable.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,8 @@ defaults: &defaults
   events:
     server: 'amqp://localhost:5672'
     exchange: 'plum_events'
+  event_queue:
+    durable: true
 
 development:
   <<: *defaults
@@ -31,3 +33,5 @@ staging:
   events:
     server: <%= ENV["POMEGRANATE_RABBITMQ_URL"] %>
     exchange: <%= ENV["POMEGRANATE_RABBITMQ_EXCHANGE"] %>
+  event_queue:
+    durable: false

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -23,6 +23,7 @@ Sneakers.logger.level = Logger::INFO
 
 WORKER_OPTIONS = {
   ack: true,
+  durable: Pomegranate.config["event_queue"]["durable"],
   threads: 5,
   prefetch: 10,
   timeout_job_after: 60,

--- a/spec/workers/figgy_event_handler_spec.rb
+++ b/spec/workers/figgy_event_handler_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe FiggyEventHandler do
         "event" => "CREATED"
       }
     end
+
     it "sends the message to the FiggyEventProcessor as a hash" do
       figgy_event_processor = instance_double(FiggyEventProcessor, process: true)
       allow(FiggyEventProcessor).to receive(:new).and_return(figgy_event_processor)
@@ -28,6 +29,7 @@ RSpec.describe FiggyEventHandler do
       expect(FiggyEventProcessor).to have_received(:new).with(msg)
       expect(handler).to have_received(:ack!)
     end
+
     it "acknowleges the message if the event is unknown" do
       figgy_event_processor = instance_double(FiggyEventProcessor, process: false)
       allow(FiggyEventProcessor).to receive(:new).and_return(figgy_event_processor)
@@ -38,8 +40,13 @@ RSpec.describe FiggyEventHandler do
       expect(FiggyEventProcessor).to have_received(:new).with(msg)
       expect(handler).to have_received(:ack!)
     end
+
     it "is configured to use an environment specific deadletter queue" do
       expect(described_class.queue_opts[:arguments][:"x-dead-letter-exchange"]).to eq "pomegranate_test-retry"
+    end
+
+    it "defaults to a durable queue" do
+      expect(described_class.queue_opts[:durable]).to eq true
     end
   end
 end


### PR DESCRIPTION
Exchanges and production queues will still be durable.
fixes #800