### PR TITLE
Fix duplicating Spotlight::CustomFields

### DIFF
--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -137,6 +137,16 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
     @exhibit_custom_fields = nil
   end
 
+  # Compare to the slug instead of the label in case the label has been modified
+  # by the user in the blacklight configuration. Without this you'll end up with
+  # proliferation of duplicate Spotlight::CustomFields.
+  def missing_keys(keys)
+    custom_field_slugs = exhibit_custom_fields.values.map(&:slug)
+    keys.reject do |key|
+      custom_field_slugs.include?(key.parameterize)
+    end
+  end
+
   def disabled_fields
     [
       "Override Title",


### PR DESCRIPTION
If a CustomField existed but had a label overwritten by the Blacklight
Configuration for the exhibit it would create a new custom field even
though it shouldn't. By comparing against the slug rather than the label it avoids that Blacklight Configuration.

Closes #731