### PR TITLE
Try Disallow: /*?*, as used in orangelight

### DIFF
--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -1,7 +1,7 @@
 <% if Rails.env.production? %>
   User-agent: *
   Crawl-delay: 10
-  Disallow: /*?
+  Disallow: /*?*
 <% else %>
   User-Agent: *
   Disallow: /

--- a/spec/views/pages/robots.text.erb_spec.rb
+++ b/spec/views/pages/robots.text.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "pages/robots.text.erb" do
     end
 
     it "slows down spiders and disallows indexing anything with a query-string" do
-      expect(response).to include "Disallow: /*?"
+      expect(response).to include "Disallow: /*?*"
       expect(response).to include "Crawl-delay: 10"
     end
   end


### PR DESCRIPTION
fixes #811