### PR TITLE
Make rails version more explicit in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'graphql-client'
 gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 gem 'rack', '>= 2.0.6'
-gem 'rails', '~> 5.1'
+gem 'rails', '~> 5.2'
 gem 'sass-rails', '~> 5.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,7 +641,7 @@ DEPENDENCIES
   pul-assets!
   puma
   rack (>= 2.0.6)
-  rails (~> 5.1)
+  rails (~> 5.2)
   rails-controller-testing
   redis-namespace
   riiif


### PR DESCRIPTION
Rails was upgraded to 5.2.3 as part of #601
closes #741