### PR TITLE
Update clean:development:all

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -92,11 +92,10 @@ if Rails.env.development? || Rails.env.test?
     end
 
     namespace :development do
-      desc "Delete all development metadata, index, and original/derivative data"
+      desc "Delete development database and index data"
       task all: :environment do
-        seeder = DataSeeder.new
-        seeder.wipe_metadata!
-        seeder.wipe_files!
+        Blacklight.default_index.connection.delete_by_query("*:*", params: { softCommit: true })
+        Rake::Task['db:reset'].invoke
       end
     end
   end


### PR DESCRIPTION
It looks like it was copied from figgy; there's no dataseeder in
pomegranate so this was failing. Just call solr delete_by_query and rake
db:reset