### PR TITLE
Check all slugs for missing keys.

### DIFF
--- a/app/services/iiif_manifest.rb
+++ b/app/services/iiif_manifest.rb
@@ -128,6 +128,7 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
     }
   end
 
+  # { "Override Title" => nil, "Title" => "Awesome Title", "Date" => "date" }
   def create_sidecars_for(*keys)
     missing_keys(keys).each do |k|
       readonly = k != "Override Title"
@@ -141,7 +142,7 @@ class IiifManifest < ::Spotlight::Resources::IiifManifest
   # by the user in the blacklight configuration. Without this you'll end up with
   # proliferation of duplicate Spotlight::CustomFields.
   def missing_keys(keys)
-    custom_field_slugs = exhibit_custom_fields.values.map(&:slug)
+    custom_field_slugs = exhibit.custom_fields.pluck(:slug)
     keys.reject do |key|
       custom_field_slugs.include?(key.parameterize)
     end

--- a/spec/models/iiif_resource_spec.rb
+++ b/spec/models/iiif_resource_spec.rb
@@ -128,6 +128,23 @@ describe IIIFResource do
     end
   end
 
+  context "when there's an existing broken Spotlight::CustomField Override Title" do
+    let(:url) { 'https://hydra-dev.princeton.edu/concern/scanned_resources/1r66j1149/manifest' }
+    it "doesn't make another" do
+      stub_manifest(url: url, fixture: '1r66j1149-expanded.json')
+      stub_metadata(id: "12345678")
+      exhibit = Spotlight::Exhibit.create title: 'Exhibit A'
+      resource = described_class.new url: url, exhibit: exhibit
+      resource.save_and_index
+      Spotlight::CustomField.create(exhibit: exhibit, field: "override-title_ssim", label: "Override Title", slug: "override-title_ssim")
+
+      custom_field_count = Spotlight::CustomField.all.size
+
+      5.times { resource.reload.save_and_index }
+      expect(Spotlight::CustomField.all.size).to eq custom_field_count
+    end
+  end
+
   context "when re-indexing an existing resource" do
     let(:url) { 'https://hydra-dev.princeton.edu/concern/scanned_resources/1r66j1149/manifest' }
 


### PR DESCRIPTION
This should fix override title creating a bunch of duplicates.

Closes #828