### PR TITLE
Increase external manifest timeout.

### DIFF
--- a/app/models/external_manifest.rb
+++ b/app/models/external_manifest.rb
@@ -2,7 +2,7 @@
 
 class ExternalManifest
   def self.load(external_uri)
-    content = open(external_uri, read_timeout: 120)
+    content = open(external_uri, read_timeout: 600)
     IIIF::Service.parse(content.read)
   end
 end


### PR DESCRIPTION
Should make getting large collection manifests take a while, but
complete.