### PR TITLE
Override exhibits partial to show four exhibit cards in a row

### DIFF
--- a/app/views/spotlight/exhibits/_exhibits.html.erb
+++ b/app/views/spotlight/exhibits/_exhibits.html.erb
@@ -1,0 +1,4 @@
+<%# Overrides partial to allow four cards per row %>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-4">
+  <%= render collection: exhibits, partial: 'exhibit_card', as: 'exhibit' %>
+</div>


### PR DESCRIPTION
Closes #1037 
Closes #1111 

![Screen Shot 2021-10-13 at 1 48 49 PM](https://user-images.githubusercontent.com/784196/137195302-56b51a24-c0ac-4dba-85e5-8383a3d95d5a.png)

