### PR TITLE
Use full font set for headers in the content section of the page.

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -20,6 +20,12 @@ h1, h2, h3, h4, h5, h6 .facets, .facets-heading {
   font-family: $font-secondary;
 }
 
+main {
+  h1, h2, h3, h4, h5, h6 {
+    font-family: $font-sans;
+  }
+}
+
 h1, h2, h3, h4, h5, h6, .st__content-block, .content-block {
   margin: 1em 0 1em;
 }


### PR DESCRIPTION
Closes #1632

Specifically this will fix https://dpul.princeton.edu/global-book-forms/feature/from-papyrus-scroll-to-codex (Iezekiḗl) and https://dpul.princeton.edu/global-book-forms/feature/the-spread-of-the-east-asian-book.

It will not fix https://dpul.princeton.edu/global-book-forms/feature/from-palm-leaves-to-loose-paper-bundles or https://dpul.princeton.edu/global-book-forms/feature/other-forms-other-materials-43fe3769-83ae-418d-98e4-0c7102a605f8, which appear to be because of Firefox's rendering engine rather than the font. @kelea99 should we make another issue? I poked around and couldn't find a way to fix it for Firefox.