### PR TITLE
Fix uploaded image class (no borders)

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -7,11 +7,11 @@
             <%# Customized these image_tags to use a different class on these images, no border %>
             <% if file[:link].present? %>
               <%= link_to file[:link], rel: 'ugc' do %>
-                <%= image_tag file[:url], class: 'img-thumbnail', alt: resource_alt_text(file, file[:caption]) %>
+                <%= image_tag file[:url], class: 'img-uploaded', alt: resource_alt_text(file, file[:caption]) %>
               <% end %>
             <% else %>
               <% alt_text = resource_alt_text(file, '') %>
-              <%= image_tag file[:url], class: 'img-thumbnail', alt: alt_text, role: alt_text.present? ? nil : 'presentation' %>
+              <%= image_tag file[:url], class: 'img-uploaded', alt: alt_text, role: alt_text.present? ? nil : 'presentation' %>
             <% end %>
             <% if file[:caption].present? %>
               <div class="caption">


### PR DESCRIPTION
closes #1688

before:

<img width="1013" height="478" alt="Screenshot 2026-04-28 at 9 19 55 AM" src="https://github.com/user-attachments/assets/ca5d0d52-11be-4a29-9d07-8e992df0fb6e" />


after:
<img width="950" height="473" alt="Screenshot 2026-04-28 at 9 22 08 AM" src="https://github.com/user-attachments/assets/76de1670-94c3-4fa9-887f-d9660924070e" />



