### PR TITLE
blacklight upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem "acts-as-taggable-on"
 gem "bixby", "~> 5.0"
-gem "blacklight", "~> 7.18"
+gem "blacklight", "~> 8.1.0"
 gem "blacklight-gallery", "~> 4.5.0"
 gem "blacklight-oembed"
 gem "blacklight-spotlight", github: "pulibrary/spotlight", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,17 +160,14 @@ GEM
       rubocop-performance
       rubocop-rails
       rubocop-rspec
-    blacklight (7.41.0)
-      deprecation
+    blacklight (8.1.0)
       globalid
-      hashdiff
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
-      rails (>= 6.1, < 8.1)
-      view_component (>= 2.74, < 4)
-      zeitwerk
+      rails (>= 6.1, < 8)
+      view_component (>= 2.66, < 4)
     blacklight-gallery (4.5.4)
       blacklight (>= 7.17, < 9)
       rails (>= 6.1, < 8)
@@ -867,7 +864,7 @@ DEPENDENCIES
   axe-core-rspec
   bcrypt_pbkdf
   bixby (~> 5.0)
-  blacklight (~> 7.18)
+  blacklight (~> 8.1.0)
   blacklight-gallery (~> 4.5.0)
   blacklight-oembed
   blacklight-spotlight!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,6 @@
 // Required by Blacklight
 //= require popper
 //= require bootstrap
-//= require blacklight/blacklight
 //= require 'blacklight_oembed/jquery.oembed.js'
 //= require blacklight_gallery
 //= require openseadragon

--- a/app/components/blacklight/response/facet_group_component.html.erb
+++ b/app/components/blacklight/response/facet_group_component.html.erb
@@ -26,9 +26,7 @@
     <% end %>
   </div>
 
-  <%= content_tag :div, id: @panel_id, class: 'facets-collapse collapse' do %>
-    <% ::Deprecation.silence(Blacklight::FacetsHelperBehavior) do %>
-      <%= @view_context.render_facet_partials @fields, response: @response %>
-    <% end %>
-  <% end %>
+  <div id="<%= @panel_id %>" class="facets-collapse collapse">
+    <%= body %>
+  </div>
 <% end %>

--- a/app/components/blacklight/response/facet_group_component.rb
+++ b/app/components/blacklight/response/facet_group_component.rb
@@ -5,23 +5,44 @@
 module Blacklight
   module Response
     # Render a group of facet fields
-    class FacetGroupComponent < ::ViewComponent::Base
+    class FacetGroupComponent < Blacklight::Component
+      renders_one :body
+
       # @param [Blacklight::Response] response
-      # @param [Array<String>] fields facet fields to render
+      # @param [Array<Blacklight::Configuration::FacetField>] fields facet fields to render
       # @param [String] title the title of the facet group section
       # @param [String] id a unique identifier for the group
-      def initialize(response:, fields: [], title: nil, id: nil)
-        @response = response
+      def initialize(id:, title: nil, fields: [], response: nil)
+        @groupname = id
+        @id = id ? "facets-#{id}" : 'facets'
+        @title = title || I18n.t("blacklight.search.#{@id}.title")
+        @panel_id = id ? "facet-panel-#{id}-collapse" : 'facet-panel-collapse'
+
+        # deprecated variables
         @fields = fields
-        @title = title
-        @id = id ? "facets-#{id}" : "facets"
-        @panel_id = id ? "facet-panel-#{id}-collapse" : "facet-panel-collapse"
+        @response = response
+      end
+
+      # Provide fallback behavior for rendering this object without a body slot
+      def before_render
+        set_slot(:body, nil) { default_body } unless body?
       end
 
       def render?
-        Deprecation.silence(Blacklight::FacetsHelperBehavior) do
-          @view_context.has_facet_values?(@fields, @response)
-        end
+        body.present?
+      end
+
+      private
+
+      # @deprecated
+      def default_body
+        Blacklight.deprecation.warn('Rendering the Blacklight::FacetGroupComponent without a body slot is deprecated.')
+        helpers.render(Blacklight::FacetComponent.with_collection(@fields, response: @response))
+      end
+
+      # @deprecated
+      def blacklight_config
+        helpers.blacklight_config
       end
     end
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -34,6 +34,7 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    config.bootstrap_version = 4
     config.raw_endpoint.enabled = true
     config.show.oembed_field = :oembed_url_ssm
     config.show.partials.insert(1, :oembed)
@@ -152,7 +153,7 @@ class CatalogController < ApplicationController
   # get a single document from the index
   # to add responses for formats other than html or json see _Blacklight::Document::Export_
   def show
-    @response, @document = search_service.fetch params[:id], exhibit: @exhibit
+    @document = search_service.fetch params[:id], exhibit: @exhibit
     respond_to do |format|
       format.html { setup_next_and_previous_documents }
       format.json { render json: { response: { document: @document } } }

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -8,12 +8,6 @@ class SolrDocument
 
   # self.unique_key = 'id'
 
-  # Email uses the semantic field mappings below to generate the body of an email.
-  SolrDocument.use_extension(Blacklight::Document::Email)
-
-  # SMS uses the semantic field mappings below to generate the body of an SMS email.
-  SolrDocument.use_extension(Blacklight::Document::Sms)
-
   class << self
     def find(id, params = {})
       solr_response = index.find(id, params)

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -4,4 +4,4 @@
   # functionality work rather than overriding functionality in several other
   # places to stay consistent with the noid.
 -%>
-<%= render Blacklight::Document::BookmarkComponent.new(document: document, bookmark_path: bookmarks_id_path(document)) if current_or_guest_user %>
+<%= render Blacklight::Document::BookmarkComponent.new(document: document, bookmark_path: bookmarks_id_path(document), action: document_action_config) if current_or_guest_user %>

--- a/app/views/catalog/_default_search_form.html.erb
+++ b/app/views/catalog/_default_search_form.html.erb
@@ -2,6 +2,5 @@
       url: main_app.search_catalog_url,
       advanced_search_url: nil,
       params: search_state.params_for_search.except(:qt),
-      search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
-      presenter: search_bar_presenter
+      search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields }
 )) %>

--- a/app/views/catalog/_default_search_form.html.erb
+++ b/app/views/catalog/_default_search_form.html.erb
@@ -2,5 +2,4 @@
       url: main_app.search_catalog_url,
       advanced_search_url: nil,
       params: search_state.params_for_search.except(:qt),
-      search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields }
 )) %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,7 +1,2 @@
 <script defer event-pagetype="Record_Page" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.pageview-props.js"></script>
-<%= render_document_main_content_partial %>
-
-<!-- <div id="sidebar" class="<%#= show_sidebar_classes %>">
-   <%#= render_document_sidebar_partial %>
-</div>
- -->
+<%= render 'show_main_content' %>

--- a/config/initializers/monkeypatches/contextual_edit_patch.rb
+++ b/config/initializers/monkeypatches/contextual_edit_patch.rb
@@ -3,11 +3,11 @@
 Rails.application.config.to_prepare do
   module ContextualEditPatch
     def edit
-      @response, @document = search_service.fetch params[:id], exhibit: @exhibit
+      @document = search_service.fetch params[:id], exhibit: @exhibit
     end
 
     def update
-      @response, @document = search_service.fetch params[:id], exhibit: @exhibit
+      @document = search_service.fetch params[:id], exhibit: @exhibit
       @document.update(current_exhibit, solr_document_params)
       @document.save
 


### PR DESCRIPTION
- **Address blacklight deprecation warnings**
- **Start a blacklight upgrade**

I handled a couple of deprecations, then updated blacklight, then went through [this upgrade guide](https://github.com/projectblacklight/blacklight/wiki/Upgrading-to-Blacklight-8). Then worked through some test failures where it turned out we had several silenced deprecations, I think mostly because we pulled code from upstream and they were in there. Eventually I got blocked by some test failures in a rtl presenter, problems with doubles and I couldn't pinpoint it. there were 17 failures when I gave up, probably half in the rtl presenters and the other half in feature tests which I didn't investigate.

One nice thing is we can upgrade blacklight without bootstrap; the several complex steps on this upgrade path can be kept pretty discrete.